### PR TITLE
ci: fix failing pages job

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: ammaraskar/sphinx-action@master
         with:
-          pre-build-command: "pip install furo"
+          pre-build-command: "pip install furo pygments==2.11.2"
           build-command: "sphinx-build -b html -W . _build"
           docs-folder: "docs/"
 


### PR DESCRIPTION
Adds pygments==2.11.2 for furo theme because of problems with versions.