### PR TITLE
fix(operation-svc): fix inconsistency in operation member retrieval and update

### DIFF
--- a/services/go/operation-svc/controller/controller.go
+++ b/services/go/operation-svc/controller/controller.go
@@ -40,10 +40,9 @@ type Store interface {
 	// UpdateOperationMembersByOperation updates the members for the operation with
 	// the given id.
 	UpdateOperationMembersByOperation(ctx context.Context, tx pgx.Tx, operationID uuid.UUID, members []uuid.UUID) error
-	// OperationMembersByOperation retrieves a paginated store.User list for the
-	// operation with the given id.
-	OperationMembersByOperation(ctx context.Context, tx pgx.Tx, operationID uuid.UUID,
-		params pagination.Params) (pagination.Paginated[store.User], error)
+	// OperationMembersByOperation retrieves the store.User list for the operation
+	// with the given id.
+	OperationMembersByOperation(ctx context.Context, tx pgx.Tx, operationID uuid.UUID) ([]store.User, error)
 	// OperationsByMember retrieves an Operation list for the member with the given
 	// id.
 	OperationsByMember(ctx context.Context, tx pgx.Tx, userID uuid.UUID) ([]store.Operation, error)

--- a/services/go/operation-svc/controller/controller_test.go
+++ b/services/go/operation-svc/controller/controller_test.go
@@ -90,10 +90,13 @@ func (m *StoreMock) UpdateOperationMembersByOperation(ctx context.Context, tx pg
 	return m.Called(ctx, tx, operationID, members).Error(0)
 }
 
-func (m *StoreMock) OperationMembersByOperation(ctx context.Context, tx pgx.Tx, operationID uuid.UUID,
-	params pagination.Params) (pagination.Paginated[store.User], error) {
-	args := m.Called(ctx, tx, operationID, params)
-	return args.Get(0).(pagination.Paginated[store.User]), args.Error(1)
+func (m *StoreMock) OperationMembersByOperation(ctx context.Context, tx pgx.Tx, operationID uuid.UUID) ([]store.User, error) {
+	args := m.Called(ctx, tx, operationID)
+	var members []store.User
+	if a := args.Get(0); a != nil {
+		members = a.([]store.User)
+	}
+	return members, args.Error(1)
 }
 
 func (m *StoreMock) OperationsByMember(ctx context.Context, tx pgx.Tx, userID uuid.UUID) ([]store.Operation, error) {

--- a/services/go/operation-svc/controller/operation_members.go
+++ b/services/go/operation-svc/controller/operation_members.go
@@ -6,7 +6,6 @@ import (
 	"github.com/jackc/pgx/v4"
 	"github.com/lefinal/meh"
 	"github.com/mobile-directing-system/mds-server/services/go/operation-svc/store"
-	"github.com/mobile-directing-system/mds-server/services/go/shared/pagination"
 	"github.com/mobile-directing-system/mds-server/services/go/shared/pgutil"
 )
 
@@ -43,11 +42,10 @@ func (c *Controller) UpdateOperationMembersByOperation(ctx context.Context, oper
 	return nil
 }
 
-// OperationMembersByOperation retrieves a paginated store.user list for the
-// operation with the given id.
-func (c *Controller) OperationMembersByOperation(ctx context.Context, operationID uuid.UUID,
-	paginationParams pagination.Params) (pagination.Paginated[store.User], error) {
-	var members pagination.Paginated[store.User]
+// OperationMembersByOperation retrieves a the store.User list for the operation
+// with the given id.
+func (c *Controller) OperationMembersByOperation(ctx context.Context, operationID uuid.UUID) ([]store.User, error) {
+	var members []store.User
 	err := pgutil.RunInTx(ctx, c.DB, func(ctx context.Context, tx pgx.Tx) error {
 		var err error
 		// Assure operation exists.
@@ -56,17 +54,14 @@ func (c *Controller) OperationMembersByOperation(ctx context.Context, operationI
 			return meh.Wrap(err, "operation from store", meh.Details{"operation_id": operationID})
 		}
 		// Retrieve members.
-		members, err = c.Store.OperationMembersByOperation(ctx, tx, operationID, paginationParams)
+		members, err = c.Store.OperationMembersByOperation(ctx, tx, operationID)
 		if err != nil {
-			return meh.Wrap(err, "operation members from store", meh.Details{
-				"operation_id":      operationID,
-				"pagination_params": paginationParams,
-			})
+			return meh.Wrap(err, "operation members from store", meh.Details{"operation_id": operationID})
 		}
 		return nil
 	})
 	if err != nil {
-		return pagination.Paginated[store.User]{}, meh.Wrap(err, "run in tx", nil)
+		return nil, meh.Wrap(err, "run in tx", nil)
 	}
 	return members, nil
 }

--- a/services/go/operation-svc/controller/users.go
+++ b/services/go/operation-svc/controller/users.go
@@ -6,7 +6,6 @@ import (
 	"github.com/jackc/pgx/v4"
 	"github.com/lefinal/meh"
 	"github.com/mobile-directing-system/mds-server/services/go/operation-svc/store"
-	"github.com/mobile-directing-system/mds-server/services/go/shared/pagination"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -39,13 +38,13 @@ func (c *Controller) DeleteUserByID(ctx context.Context, tx pgx.Tx, userID uuid.
 	// Remove from all operations.
 	updatedMembersByOperation := make(map[uuid.UUID][]uuid.UUID, len(currentlyMemberOf))
 	for _, operation := range currentlyMemberOf {
-		operationMembers, err := c.Store.OperationMembersByOperation(ctx, tx, operation.ID, pagination.Params{Limit: 0})
+		operationMembers, err := c.Store.OperationMembersByOperation(ctx, tx, operation.ID)
 		if err != nil {
 			return meh.Wrap(err, "operation members for assigned operation",
 				meh.Details{"operation_id": operation.ID})
 		}
-		newMembers := make([]uuid.UUID, 0, len(operationMembers.Entries))
-		for _, member := range operationMembers.Entries {
+		newMembers := make([]uuid.UUID, 0, len(operationMembers))
+		for _, member := range operationMembers {
 			if member.ID != userID {
 				newMembers = append(newMembers, member.ID)
 			}

--- a/services/go/operation-svc/endpoints/endpoints_test.go
+++ b/services/go/operation-svc/endpoints/endpoints_test.go
@@ -47,10 +47,13 @@ func (m *StoreMock) UpdateOperation(ctx context.Context, operation store.Operati
 	return m.Called(ctx, operation).Error(0)
 }
 
-func (m *StoreMock) OperationMembersByOperation(ctx context.Context, operationID uuid.UUID,
-	paginationParams pagination.Params) (pagination.Paginated[store.User], error) {
-	args := m.Called(ctx, operationID, paginationParams)
-	return args.Get(0).(pagination.Paginated[store.User]), args.Error(1)
+func (m *StoreMock) OperationMembersByOperation(ctx context.Context, operationID uuid.UUID) ([]store.User, error) {
+	args := m.Called(ctx, operationID)
+	var members []store.User
+	if a := args.Get(0); a != nil {
+		members = a.([]store.User)
+	}
+	return members, args.Error(1)
 }
 
 func (m *StoreMock) UpdateOperationMembersByOperation(ctx context.Context, operationID uuid.UUID, members []uuid.UUID) error {


### PR DESCRIPTION
BREAKING-CHANGE: Operation member retrieval no longer returns a paginated list, but all members.

Closes #70