### PR TITLE
fix(logistics-svc): fix broken event-handling of operation member updates

### DIFF
--- a/services/go/logistics-svc/store/operations.go
+++ b/services/go/logistics-svc/store/operations.go
@@ -127,7 +127,7 @@ func (m *Mall) UpdateOperationMembersByOperation(ctx context.Context, tx pgx.Tx,
 	affectedEntries := make([]uuid.UUID, 0)
 	for affectedEntriesRows.Next() {
 		var entryID uuid.UUID
-		err = affectedEntriesRows.Scan(&affectedEntries)
+		err = affectedEntriesRows.Scan(&entryID)
 		if err != nil {
 			return mehpg.NewScanRowsErr(err, "scan affected-entries-row", affectedEntriesQuery)
 		}


### PR DESCRIPTION
Fixes an issue where retrieves rows from the database where not scanned correctly.

Closes #81