### PR TITLE
feat: add is-active-flag to channels

### DIFF
--- a/docs/sites/address-book.rst
+++ b/docs/sites/address-book.rst
@@ -184,6 +184,8 @@ For example, an email channel is used for sending an email containing the intel 
 A radio channel might forward intel to a radio operator, that calls the recipient.
 Each channel has a unique priority, timeout and minimum importance for intel.
 
+The is-active-Flag of a channel describes whether the channel is available for intel-delivery.
+
 Currently, the following channel types are supported, but not all implemented:
 
 - (**Coming soon** |:rocket:|) **Direct** (`direct`): Use, if the recipient can be contacted directly, for example by talking.
@@ -268,6 +270,7 @@ Setting channels for global entries or ones, being associated to other users tha
     [
         {
             "entry": "<entry_id>",
+            "is_active": false,
             "label": "<label>",
             "type": "<channel_type>",
             "priority": 20,
@@ -296,6 +299,7 @@ Response:
         {
             "id": "<channel_id>",
             "entry": "<entry_id>",
+            "is_active": false,
             "label": "<label>",
             "type": "<channel_type>",
             "priority": 20,

--- a/services/go/logistics-svc/app/db-migrations/001_init_up.sql
+++ b/services/go/logistics-svc/app/db-migrations/001_init_up.sql
@@ -77,6 +77,7 @@ create table channels
     id             uuid primary key not null default uuid_generate_v4(),
     entry          uuid             not null references address_book_entries (id)
         on delete restrict on update restrict,
+    is_active      boolean          not null,
     label          varchar          not null,
     "type"         varchar          not null,
     priority       int              not null,

--- a/services/go/logistics-svc/endpoints/channel_handlers.go
+++ b/services/go/logistics-svc/endpoints/channel_handlers.go
@@ -20,6 +20,7 @@ import (
 type publicChannel struct {
 	ID            uuid.UUID       `json:"id"`
 	Entry         uuid.UUID       `json:"entry"`
+	IsActive      bool            `json:"is_active"`
 	Label         string          `json:"label"`
 	Type          string          `json:"type"`
 	Priority      int32           `json:"priority"`
@@ -33,10 +34,12 @@ func publicChannelFromStore(s store.Channel) (publicChannel, error) {
 	p := publicChannel{
 		ID:            s.ID,
 		Entry:         s.Entry,
+		IsActive:      s.IsActive,
 		Label:         s.Label,
 		Type:          string(s.Type),
 		Priority:      s.Priority,
 		MinImportance: s.MinImportance,
+		Details:       nil,
 		Timeout:       s.Timeout,
 	}
 	// Convert details.
@@ -83,6 +86,7 @@ func storeChannelFromPublic(p publicChannel) (store.Channel, error) {
 	s := store.Channel{
 		ID:            p.ID,
 		Entry:         p.Entry,
+		IsActive:      p.IsActive,
 		Label:         p.Label,
 		Type:          store.ChannelType(p.Type),
 		Priority:      p.Priority,

--- a/services/go/logistics-svc/endpoints/channel_handlers_test.go
+++ b/services/go/logistics-svc/endpoints/channel_handlers_test.go
@@ -35,6 +35,7 @@ func (suite *storeChannelFromPublicSuite) SetupTest() {
 	suite.samplePublicChannel = publicChannel{
 		ID:            testutil.NewUUIDV4(),
 		Entry:         testutil.NewUUIDV4(),
+		IsActive:      true,
 		Label:         "flavor",
 		Type:          string(store.ChannelTypeInAppNotification),
 		Priority:      900,
@@ -45,6 +46,7 @@ func (suite *storeChannelFromPublicSuite) SetupTest() {
 	suite.sampleStoreChannel = store.Channel{
 		ID:            suite.samplePublicChannel.ID,
 		Entry:         suite.samplePublicChannel.Entry,
+		IsActive:      suite.samplePublicChannel.IsActive,
 		Label:         suite.samplePublicChannel.Label,
 		Type:          store.ChannelType(suite.samplePublicChannel.Type),
 		Priority:      suite.samplePublicChannel.Priority,
@@ -84,6 +86,7 @@ func testStoreChannelDetailsFromPublic[From any, To store.ChannelDetails](t *tes
 	pChan := publicChannel{
 		ID:            testutil.NewUUIDV4(),
 		Entry:         testutil.NewUUIDV4(),
+		IsActive:      true,
 		Label:         "flavor",
 		Type:          string(chanType),
 		Priority:      900,
@@ -96,6 +99,7 @@ func testStoreChannelDetailsFromPublic[From any, To store.ChannelDetails](t *tes
 	assert.Equal(t, store.Channel{
 		ID:            pChan.ID,
 		Entry:         pChan.Entry,
+		IsActive:      pChan.IsActive,
 		Label:         pChan.Label,
 		Type:          chanType,
 		Priority:      pChan.Priority,
@@ -191,6 +195,7 @@ func (suite *publicChannelFromStoreSuite) SetupTest() {
 	suite.sampleStoreChannel = store.Channel{
 		ID:            testutil.NewUUIDV4(),
 		Entry:         testutil.NewUUIDV4(),
+		IsActive:      true,
 		Label:         "flavor",
 		Type:          store.ChannelTypeInAppNotification,
 		Priority:      900,
@@ -201,6 +206,7 @@ func (suite *publicChannelFromStoreSuite) SetupTest() {
 	suite.samplePublicChannel = publicChannel{
 		ID:            suite.sampleStoreChannel.ID,
 		Entry:         suite.sampleStoreChannel.Entry,
+		IsActive:      suite.sampleStoreChannel.IsActive,
 		Label:         suite.sampleStoreChannel.Label,
 		Type:          string(suite.sampleStoreChannel.Type),
 		Priority:      suite.sampleStoreChannel.Priority,
@@ -243,6 +249,7 @@ func testPublicChannelDetailsFromStore[From store.ChannelDetails, To any](t *tes
 	sChan := store.Channel{
 		ID:            testutil.NewUUIDV4(),
 		Entry:         testutil.NewUUIDV4(),
+		IsActive:      true,
 		Label:         "flavor",
 		Type:          chanType,
 		Priority:      900,
@@ -255,6 +262,7 @@ func testPublicChannelDetailsFromStore[From store.ChannelDetails, To any](t *tes
 	assert.Equal(t, publicChannel{
 		ID:            sChan.ID,
 		Entry:         sChan.Entry,
+		IsActive:      sChan.IsActive,
 		Label:         sChan.Label,
 		Type:          string(chanType),
 		Priority:      sChan.Priority,
@@ -367,6 +375,7 @@ func (suite *handleUpdateChannelsByAddressBookEntrySuite) SetupTest() {
 		{
 			ID:            testutil.NewUUIDV4(),
 			Entry:         suite.sampleEntryID,
+			IsActive:      true,
 			Label:         "quarter",
 			Type:          string(store.ChannelTypeInAppNotification),
 			Priority:      966,
@@ -376,6 +385,7 @@ func (suite *handleUpdateChannelsByAddressBookEntrySuite) SetupTest() {
 		},
 		{
 			Entry:         suite.sampleEntryID,
+			IsActive:      true,
 			Label:         "towel",
 			Type:          string(store.ChannelTypePhoneCall),
 			Priority:      40,

--- a/services/go/logistics-svc/eventport/notifiers.go
+++ b/services/go/logistics-svc/eventport/notifiers.go
@@ -273,6 +273,7 @@ func (p *Port) NotifyAddressBookEntryChannelsUpdated(ctx context.Context, tx pgx
 		mappedChannel := event.AddressBookEntryChannelsUpdatedChannel{
 			ID:            channel.ID,
 			Entry:         channel.Entry,
+			IsActive:      channel.IsActive,
 			Label:         channel.Label,
 			Priority:      channel.Priority,
 			MinImportance: channel.MinImportance,

--- a/services/go/logistics-svc/eventport/notifiers_test.go
+++ b/services/go/logistics-svc/eventport/notifiers_test.go
@@ -475,6 +475,7 @@ func (suite *PortNotifyAddressBookEntryChannelsUpdatedSuite) SetupTest() {
 		{
 			ID:            testutil.NewUUIDV4(),
 			Entry:         suite.sampleEntryID,
+			IsActive:      true,
 			Label:         "",
 			Type:          store.ChannelTypeDirect,
 			Priority:      1,
@@ -487,6 +488,7 @@ func (suite *PortNotifyAddressBookEntryChannelsUpdatedSuite) SetupTest() {
 		{
 			ID:            testutil.NewUUIDV4(),
 			Entry:         suite.sampleEntryID,
+			IsActive:      false,
 			Label:         "give",
 			Type:          store.ChannelTypeForwardToUser,
 			Priority:      -1,
@@ -511,6 +513,7 @@ func (suite *PortNotifyAddressBookEntryChannelsUpdatedSuite) SetupTest() {
 				{
 					ID:            suite.sampleChannels[0].ID,
 					Entry:         suite.sampleEntryID,
+					IsActive:      suite.sampleChannels[0].IsActive,
 					Label:         "",
 					Type:          event.AddressBookEntryChannelTypeDirect,
 					Priority:      1,
@@ -523,6 +526,7 @@ func (suite *PortNotifyAddressBookEntryChannelsUpdatedSuite) SetupTest() {
 				{
 					ID:            suite.sampleChannels[1].ID,
 					Entry:         suite.sampleEntryID,
+					IsActive:      suite.sampleChannels[1].IsActive,
 					Label:         "give",
 					Type:          event.AddressBookEntryChannelTypeForwardToUser,
 					Priority:      -1,

--- a/services/go/logistics-svc/store/channels.go
+++ b/services/go/logistics-svc/store/channels.go
@@ -29,6 +29,9 @@ type Channel struct {
 	ID uuid.UUID
 	// Entry is the id of the entry the channel is assigned to.
 	Entry uuid.UUID
+	// IsActive describes whether the channel is currently active and available for
+	// delivery or not.
+	IsActive bool
 	// Label of the channel for better human-readability.
 	Label string
 	// Type of the channel.
@@ -136,6 +139,7 @@ func (m *Mall) channelMetadataByAddressBookEntry(ctx context.Context, tx pgx.Tx,
 	q, _, err := m.dialect.From(goqu.T("channels")).
 		Select(goqu.C("id"),
 			goqu.C("entry"),
+			goqu.C("is_active"),
 			goqu.C("label"),
 			goqu.C("type"),
 			goqu.C("priority"),
@@ -156,6 +160,7 @@ func (m *Mall) channelMetadataByAddressBookEntry(ctx context.Context, tx pgx.Tx,
 		err = rows.Scan(&channel.ID,
 			&channel.Entry,
 			&channel.Label,
+			&channel.IsActive,
 			&channel.Type,
 			&channel.Priority,
 			&channel.MinImportance,
@@ -234,6 +239,7 @@ func (m *Mall) CreateChannelWithDetails(ctx context.Context, tx pgx.Tx, channel 
 	// Create channel itself.
 	q, _, err := m.dialect.Insert(goqu.T("channels")).Rows(goqu.Record{
 		"entry":          channel.Entry,
+		"is_active":      channel.IsActive,
 		"label":          channel.Label,
 		"type":           channel.Type,
 		"priority":       channel.Priority,
@@ -303,6 +309,7 @@ func (m *Mall) ChannelMetadataByID(ctx context.Context, tx pgx.Tx, channelID uui
 	q, _, err := m.dialect.From(goqu.T("channels")).
 		Select(goqu.C("id"),
 			goqu.C("entry"),
+			goqu.C("is_active"),
 			goqu.C("label"),
 			goqu.C("type"),
 			goqu.C("priority"),
@@ -323,6 +330,7 @@ func (m *Mall) ChannelMetadataByID(ctx context.Context, tx pgx.Tx, channelID uui
 	}
 	err = rows.Scan(&channel.ID,
 		&channel.Entry,
+		&channel.IsActive,
 		&channel.Label,
 		&channel.Type,
 		&channel.Priority,

--- a/services/go/logistics-svc/store/intel_delivery.go
+++ b/services/go/logistics-svc/store/intel_delivery.go
@@ -346,6 +346,7 @@ func (m *Mall) NextChannelForDeliveryAttempt(ctx context.Context, tx pgx.Tx, del
 				goqu.I("intel_delivery_attempts.channel").Eq(goqu.I("channels.id")))).
 		Select(goqu.I("channels.id"),
 			goqu.I("channels.entry"),
+			goqu.I("channels.is_active"),
 			goqu.I("channels.label"),
 			goqu.I("channels.type"),
 			goqu.I("channels.priority"),
@@ -353,6 +354,7 @@ func (m *Mall) NextChannelForDeliveryAttempt(ctx context.Context, tx pgx.Tx, del
 			goqu.I("channels.timeout")).
 		Where(goqu.I("intel_deliveries.id").Eq(deliveryID),
 			goqu.I("intel_delivery_attempts.id").IsNull(),
+			goqu.I("channels.is_active").IsTrue(),
 			goqu.I("intel.importance").Gte(goqu.I("channels.min_importance"))).
 		Order(goqu.I("channels.priority").Desc()).
 		Limit(1).ToSQL()
@@ -370,6 +372,7 @@ func (m *Mall) NextChannelForDeliveryAttempt(ctx context.Context, tx pgx.Tx, del
 	var channel Channel
 	err = rows.Scan(&channel.ID,
 		&channel.Entry,
+		&channel.IsActive,
 		&channel.Label,
 		&channel.Type,
 		&channel.Priority,

--- a/services/go/shared/event/address_book.go
+++ b/services/go/shared/event/address_book.go
@@ -154,6 +154,9 @@ type AddressBookEntryChannelsUpdatedChannel struct {
 	ID uuid.UUID `json:"id"`
 	// Entry is the id of the entry the channel is assigned to.
 	Entry uuid.UUID `json:"entry"`
+	// IsActive describes whether the channel is active and therefore available for
+	// delivery.
+	IsActive bool `json:"is_active"`
 	// Label of the channel for better human-readability.
 	Label string `json:"label"`
 	// Type of the channel.


### PR DESCRIPTION
Adds the is-active-Flag to channels that is used for marking channels as (not) available for (auto) intel-delivery.

Closes #95