### PR TITLE
feat: move websocket authentication to messages

### DIFF
--- a/docs/sites/websocket.rst
+++ b/docs/sites/websocket.rst
@@ -20,3 +20,10 @@ Each message is of the following format:
     }
 
 Based on the channel, the hub will forward to the correct service and for messages from a service, the channel will be set accordingly.
+
+Authentication
+==============
+
+Authentication via HTTP request headers when initiating the WebSocket connection is not possible with the Browser WebSocket API.
+Therefore, the first client message over the WebSocket connection is expected to consist of the authentication token.
+This message must not be in the format described above but in plain-text.

--- a/k8s/500_mds-api-gateway-svc.yaml
+++ b/k8s/500_mds-api-gateway-svc.yaml
@@ -147,6 +147,7 @@ metadata:
 data:
   MDS_DB_CONN_STRING: postgresql://mds:mds@mds-api-gateway-svc-postgres-service/mds-api-gateway-svc
   MDS_KAFKA_ADDR: kafka-cluster-kafka-bootstrap.kafka:9092
+  MDS_INTERNAL_SERVE_ADDR: :8070
   MDS_REDIS_ADDR: mds-api-gateway-svc-redis-service:6379
   MDS_SERVE_ADDR: :8080
   MDS_FORWARD_ADDR: internal-ingress-nginx-controller.internal-ingress-nginx
@@ -162,8 +163,12 @@ spec:
   selector:
     app: mds-api-gateway-svc
   ports:
-    - port: 3000
+    - name: public-endpionts
+      port: 3000
       targetPort: 8080
+    - name: internal-endpoints
+      port: 2090
+      targetPort: 8070
 ---
 # API Gateway svc deployment.
 apiVersion: apps/v1
@@ -189,6 +194,7 @@ spec:
                 name: mds-api-gateway-svc-config
           ports:
             - containerPort: 8080
+            - containerPort: 8070
           livenessProbe:
             httpGet:
               port: 31234

--- a/k8s/830_mds-ws-hub-svc.yaml
+++ b/k8s/830_mds-ws-hub-svc.yaml
@@ -8,6 +8,7 @@ metadata:
 data:
   MDS_SERVE_ADDR: :8080
   MDS_LOG_LEVEL: debug
+  MDS_AUTH_TOKEN_RESOLVE_URL: http://mds-api-gateway-svc-service:2090/tokens/resolve-public
   MDS_ROUTER_CONFIG_PATH: /app-config/router.json
 ---
 apiVersion: v1

--- a/services/go/api-gateway-svc/app/app.go
+++ b/services/go/api-gateway-svc/app/app.go
@@ -117,11 +117,19 @@ func Run(ctx context.Context) error {
 		}
 		return nil
 	})
-	// Serve endpoints.
+	// Serve public endpoints.
 	eg.Go(func() error {
-		err := endpoints.Serve(egCtx, logger.Named("endpoints"), c.ServeAddr, c.ForwardAddr, ctrl)
+		err := endpoints.Serve(egCtx, logger.Named("public-endpoints"), c.ServeAddr, c.ForwardAddr, ctrl)
 		if err != nil {
-			return meh.Wrap(err, "serve endpoints", nil)
+			return meh.Wrap(err, "serve public endpoints", nil)
+		}
+		return nil
+	})
+	// Serve internal endpoints
+	eg.Go(func() error {
+		err := endpoints.ServeInternal(egCtx, logger.Named("internal-endpoints"), c.InternalServeAddr, ctrl)
+		if err != nil {
+			return meh.Wrap(err, "serve internal endpoints", nil)
 		}
 		return nil
 	})

--- a/services/go/api-gateway-svc/app/config.go
+++ b/services/go/api-gateway-svc/app/config.go
@@ -9,6 +9,8 @@ import (
 )
 
 const (
+	// envInternalServeAddr for config.InternalServeAddr.
+	envInternalServeAddr = "MDS_INTERNAL_SERVE_ADDR"
 	// envRedisAddr for config.RedisAddr.
 	envRedisAddr = "MDS_REDIS_ADDR"
 	// envForwardAddr for config.ForwardAddr.
@@ -19,6 +21,8 @@ const (
 
 type config struct {
 	basicconfig.Config
+	// InternalServeAddr is the address under which to serve internal endpoints.
+	InternalServeAddr string `json:"internal_serve_addr"`
 	// RedisAddr is the address under which Redis is reachable.
 	RedisAddr string `json:"redis_addr"`
 	// ForwardAddr is the address to forward handled requests to.
@@ -34,6 +38,8 @@ func parseConfigFromEnv() (config, error) {
 	if err != nil {
 		return config{}, meh.Wrap(err, "parse basic config from env", nil)
 	}
+	// Internal serve address.
+	c.InternalServeAddr = os.Getenv(envInternalServeAddr)
 	// Redis address.
 	c.RedisAddr = os.Getenv(envRedisAddr)
 	if c.RedisAddr == "" {

--- a/services/go/api-gateway-svc/controller/proxy.go
+++ b/services/go/api-gateway-svc/controller/proxy.go
@@ -9,9 +9,8 @@ import (
 	"math/rand"
 )
 
-// Proxy checks if the user is logged in (returned as second return value) and
-// generates an internal authentication token, which will be passed with the
-// forwarded request.
+// Proxy checks if the user is logged in and generates an internal authentication
+// token, which will be passed with the forwarded request.
 func (c *Controller) Proxy(ctx context.Context, publicToken string) (string, error) {
 	authToken, err := c.gatherProxyToken(ctx, publicToken)
 	if err != nil {

--- a/services/go/api-gateway-svc/endpoints/endpoints_test.go
+++ b/services/go/api-gateway-svc/endpoints/endpoints_test.go
@@ -2,9 +2,11 @@ package endpoints
 
 import (
 	"context"
+	"github.com/gofrs/uuid"
 	"github.com/mobile-directing-system/mds-server/services/go/api-gateway-svc/controller"
 	"github.com/mobile-directing-system/mds-server/services/go/shared/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"net/http"
@@ -14,6 +16,25 @@ import (
 )
 
 const timeout = 5 * time.Second
+
+// StoreMock mocks Store.
+type StoreMock struct {
+	mock.Mock
+}
+
+func (m *StoreMock) Login(ctx context.Context, username string, pass string, requestMetadata controller.AuthRequestMetadata) (uuid.UUID, string, bool, error) {
+	args := m.Called(ctx, username, pass, requestMetadata)
+	return args.Get(0).(uuid.UUID), args.String(1), args.Bool(2), args.Error(3)
+}
+
+func (m *StoreMock) Logout(ctx context.Context, publicToken string, requestMetadata controller.AuthRequestMetadata) error {
+	return m.Called(ctx, publicToken, requestMetadata).Error(0)
+}
+
+func (m *StoreMock) Proxy(ctx context.Context, token string) (string, error) {
+	args := m.Called(ctx, token)
+	return args.String(0), args.Error(1)
+}
 
 func Test_populateAPIV1Routes(t *testing.T) {
 	r := testutil.NewGinEngine()

--- a/services/go/ws-hub-svc/app/app.go
+++ b/services/go/ws-hub-svc/app/app.go
@@ -47,7 +47,7 @@ func Run(ctx context.Context) error {
 	}
 	// Setup hub.
 	gateConfigs := gateConfigsFromConfig(c.Router.Gates)
-	wsHub := ws.NewNetHub(egCtx, logger.Named("ws"), gateConfigs)
+	wsHub := ws.NewNetHub(egCtx, logger.Named("ws"), c.AuthTokenResolveURL, gateConfigs)
 	// Serve endpoints.
 	eg.Go(func() error {
 		err := endpoints.Serve(egCtx, logger.Named("endpoints"), c.ServeAddr, wsHub)

--- a/services/go/ws-hub-svc/ws/authentication.go
+++ b/services/go/ws-hub-svc/ws/authentication.go
@@ -1,0 +1,81 @@
+package ws
+
+import (
+	"context"
+	"fmt"
+	"github.com/lefinal/meh"
+	"github.com/mobile-directing-system/mds-server/services/go/shared/wsutil"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// TokenResolver is used for resolving public authentication tokens to internal
+// ones for WebSocket communication.
+type TokenResolver interface {
+	// ResolvePublicToken resolves the given public token to the internal one.
+	ResolvePublicToken(ctx context.Context, publicToken string) (string, error)
+}
+
+// tokenResolver is the implementation of TokenResolver.
+type tokenResolver struct {
+	httpClient *http.Client
+	resolveURL *url.URL
+}
+
+func (res tokenResolver) ResolvePublicToken(ctx context.Context, publicToken string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, res.resolveURL.String(), strings.NewReader(publicToken))
+	if err != nil {
+		return "", meh.NewInternalErrFromErr(err, "new request", meh.Details{"resolve_url": res.resolveURL})
+	}
+	response, err := res.httpClient.Do(req)
+	if err != nil {
+		return "", meh.NewInternalErrFromErr(err, "new request", meh.Details{"req_url": req.URL.String()})
+	}
+	defer func() { _ = response.Body.Close() }()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return "", meh.NewInternalErrFromErr(err, "read response body", meh.Details{
+			"req_url":              req.URL.String(),
+			"response_status":      response.Status,
+			"response_status_code": response.StatusCode,
+		})
+	}
+	switch response.StatusCode {
+	case http.StatusNotFound:
+		return "", meh.NewNotFoundErr("response: not found", meh.Details{
+			"req_url":              req.URL.String(),
+			"response_status":      response.Status,
+			"response_status_code": response.StatusCode,
+			"response_body":        body,
+		})
+	case http.StatusOK:
+		return string(body), nil
+	default:
+		return "", meh.NewInternalErr(fmt.Sprintf("unexpected status code: %d", response.StatusCode), meh.Details{
+			"req_url":              req.URL.String(),
+			"response_status":      response.Status,
+			"response_status_code": response.StatusCode,
+			"response_body":        body,
+		})
+	}
+}
+
+// readAuth reads the first message from the given wsutil.Client and returns it's
+// content. The use case is that we expect the first message to be the value that
+// would normally be set in the Authorization-header.
+func readAuth(ctx context.Context, clientClient wsutil.Client, resolver TokenResolver) (string, error) {
+	var publicToken string
+	select {
+	case <-ctx.Done():
+		return "", meh.NewBadInputErr("timeout while waiting for authentication message", nil)
+	case rawMessage := <-clientClient.RawConnection().ReceiveRaw():
+		publicToken = string(rawMessage)
+	}
+	resolvedInternalToken, err := resolver.ResolvePublicToken(ctx, publicToken)
+	if err != nil {
+		return "", meh.Wrap(err, "resolve public token", nil)
+	}
+	return resolvedInternalToken, nil
+}


### PR DESCRIPTION
Authentication with HTTP headers is not possible with common browser's WebSocket APIs. Therefore, the authentication approach was changed. Each WebSocket connection to clients now expects a start message, consisting only of the authentication token.

Closes #129