### PR TITLE
fix(shared): decrease message inbox processing error cooldown

### DIFF
--- a/services/go/shared/kafkautil/inbox_outbox.go
+++ b/services/go/shared/kafkautil/inbox_outbox.go
@@ -292,7 +292,7 @@ func (c *connector) Read(ctx context.Context, txSupplier pgutil.DBTxSupplier, re
 
 const (
 	processIncomingPollWait      = 500 * time.Millisecond
-	processIncomingErrorCooldown = 3 * time.Second
+	processIncomingErrorCooldown = 1 * time.Second
 )
 
 func (c *connector) ProcessIncoming(ctx context.Context, txSupplier pgutil.DBTxSupplier, handlerFn HandlerFunc) error {


### PR DESCRIPTION
Decreases the processing cooldown from 3 seconds to 1 second as a temporary workaround for #186.